### PR TITLE
part_of_compound hook and support nullary match hooks

### DIFF
--- a/replacy/__init__.py
+++ b/replacy/__init__.py
@@ -80,7 +80,13 @@ class ReplaceMatcher:
 
             # predicate - filled template ex. succeeded_by_word("to")
             # will match "in addition to..." but not "in addition, ..."
-            pred = template(hook["args"])
+            args = hook.get("args", None)
+            if args is not None:
+                # the match_hook needs arguments
+                pred = template(hook["args"])
+            else:
+                # the match_hook is nullary
+                pred = template()
 
             # to confuse people for centuries to come ...
             # negate, since positive breaks matching

--- a/replacy/custom_patterns.py
+++ b/replacy/custom_patterns.py
@@ -45,3 +45,15 @@ def surrounded_by_phrase(phrase):
         return preceeds and follows
 
     return _surrounded_by_hook
+
+
+def part_of_compound():
+    def _word_is_part_of_compound_hook(doc, start, end):
+        head = doc[start]
+        is_compound = head.dep_ == "compound"
+        is_part_of_compound = any(
+            [t.dep_ == "compound" and t.head == head for t in doc]
+        )
+        return is_compound or is_part_of_compound
+
+    return _word_is_part_of_compound_hook

--- a/replacy/resources/match_dict.json
+++ b/replacy/resources/match_dict.json
@@ -64,5 +64,38 @@
         "description": "The expression is \"make do\".",
         "category": "R:VERB",
         "unexpected": "replaCy should handle arbitrary properties here, and attach them to the relevant spans"
+    },
+    "requirement": {
+        "patterns": [
+            {
+                "LEMMA": "requirement",
+                "POS": "NOUN",
+                "TEMPLATE_ID": 1
+            }
+        ],
+        "suggestions": [
+            [
+                {
+                    "TEXT": "need",
+                    "FROM_TEMPLATE_ID": 1
+                }
+            ]
+        ],
+        "match_hook": [
+            {
+                "name": "part_of_compound",
+                "match_if_predicate_is": false
+            }
+        ],
+        "test": {
+            "positive": [
+                "The system has the following requirements: blood of a virgin, suffering, and cat food.",
+                "Our immediate requirement is extra staff."
+            ],
+            "negative": [
+                "There is a residency requirement for obtaining citizenship.",
+                "What is the minimum entrance requirement for this course?"
+            ]
+        }
     }
 }

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,29 @@
+import json
+
+import pytest
+import spacy
+from replacy import ReplaceMatcher
+from replacy.db import get_match_dict
+
+nlp = spacy.load("en_core_web_sm")
+
+with open("replacy/resources/match_dict.json", "r") as md:
+    match_dict = json.load(md)
+    r_matcher = ReplaceMatcher(nlp, match_dict)
+
+
+# @TODO this should be more clear
+# also, if the match_dict.json changes, this test breaks
+# maybe we should build the match dict from a python dict, like in test_custom_props?
+def test_part_of_compound():
+    pos = "Our immediate requirement is extra staff."
+    neg = "There is a residency requirement for obtaining citizenship."
+    p_span = r_matcher(pos)[0]
+    n_span = r_matcher(neg)
+    assert p_span.text == "requirement", "part_of_compound hook should work"
+    assert (
+        len(n_span) == 0
+    ), "part_of_compound working means not matching when part of compound"
+
+
+# @TODO test the rest of the functions in custom_patterns.py


### PR DESCRIPTION
This introduces the hook `part_of_compound`, which identifies if the matched word is part of a compound phrase, and allows support for nullary match hooks, which `part_of_compound` is