### PR TITLE
Eng 7251  support multiple whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ You might want to project nonstandard signs into whitespaces before processing,
 
 but getting rid of multiple spaces is not always possible (this would change span char ranges).
 Since extra spaces are grouped as one token with propery `IS_SPACE: True`, 
-patterns in `match_dict` should add extra whitespace tokens:
+patterns in `match_dict` should have extra whitespace tokens:
 
 ex. 
 

--- a/README.md
+++ b/README.md
@@ -229,3 +229,43 @@ from replacy.db import load_json
 match_dict = load_json('/path/to/your/match/dict')
 ReplaceMatcher.validate_match_dict(match_dict)
 ```
+
+## Multiple spaces support
+
+Sometimes text input includes unwated signs, such as:
+- non printable unicode signs (see: https://www.soscisurvey.de/tools/view-chars.php)
+- non standard whitespaces (see: https://en.wikipedia.org/wiki/Whitespace_character)
+
+ex. `"Here␣is␣a\u180E\u200Bproblem."`
+
+For SpaCy, only most common ascii whitespace `\u0020` is translated as a whitespace spearator.
+
+You might want to project nonstandard signs into whitespaces before processing,
+
+`"Here␣is␣a\u180E\u200Bproblem." -> "Here␣is␣a␣␣problem."`
+
+but getting rid of multiple spaces is not always possible (this would change span char ranges).
+Since extra spaces are grouped as one token with propery `IS_SPACE: True`, 
+patterns in `match_dict` should add extra whitespace tokens:
+
+ex. 
+
+```
+"patterns": [
+                {
+                    "LOWER": "a"
+                },
+                {
+                    "IS_SPACE": True, "OP": "?"
+                },
+                {
+                    "LOWER": "problem"
+                }
+            ]
+```
+To keep `preceded_by...` and `succeeded_by...` match hooks working, add whitespace tokens before and after each pattern.
+In order to add optional whitespace tokens to all patterns in your  `match_dict`, use:
+
+`r_matcher = ReplaceMatcher(nlp, match_dict, allow_multiple_whitespaces=True)`
+
+By default `allow_multiple_whitespaces` is set to `False`.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ span._.suggestions
 # >>> ['exacts']
 ```
 
+## Input
+
+ReplaceMatcher accepts both text and spaCy doc.
+```python
+# text is ok
+span = r_matcher("She extracts reverge.")[0]
+
+# doc is ok too
+but also:
+doc = nlp("She extracts reverge.")
+span = r_matcher(doc)[0]
+```
 ## match_dict.json format
 
 Here is a minimal `match_dict.json`:

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ ex.
             ]
 ```
 To keep `preceded_by...` and `succeeded_by...` match hooks working, add whitespace tokens before and after each pattern.
-In order to add optional whitespace tokens to all patterns in your  `match_dict`, use:
+In order to automatically add whitespace tokens to all patterns in your  `match_dict`, use:
 
 `r_matcher = ReplaceMatcher(nlp, match_dict, allow_multiple_whitespaces=True)`
 

--- a/replacy/__init__.py
+++ b/replacy/__init__.py
@@ -214,7 +214,7 @@ class ReplaceMatcher:
             they may appear after normalizing nonstandard whitespaces
             ex. Here␣is␣a\u180E\u200Bproblem." -> "Here␣is␣a␣␣problem."
             pattern can be preceded and followed by whitespace tokens
-            to keep preceded_by... with and suceeded_by... with match hooks working
+            to keep preceded_by... with and succeeded_by... with match hooks working
             """
             if self.allow_multiple_whitespaces:
 

--- a/replacy/__init__.py
+++ b/replacy/__init__.py
@@ -218,7 +218,7 @@ class ReplaceMatcher:
             """
             if self.allow_multiple_whitespaces:
 
-                white_pattern = {"IS_SPACE": True, "OP": "*"}
+                white_pattern = {"IS_SPACE": True, "OP": "?"}
 
                 normalized_patterns = [white_pattern]
                 for p in patterns:

--- a/replacy/__init__.py
+++ b/replacy/__init__.py
@@ -54,12 +54,14 @@ class ReplaceMatcher:
         match_dict=None,
         forms_lookup=None,
         custom_match_hooks: Optional[ModuleType] = None,
+        allow_multiple_whitespaces=False,
     ):
         self.default_match_hooks = default_match_hooks
         self.custom_match_hooks = custom_match_hooks
         self.nlp = nlp
         self.match_dict = match_dict if match_dict else get_match_dict()
         self.forms_lookup = forms_lookup if forms_lookup else get_forms_lookup()
+        self.allow_multiple_whitespaces  = allow_multiple_whitespaces
 
         self.matcher = Matcher(self.nlp.vocab)
         self._init_matcher()
@@ -207,6 +209,22 @@ class ReplaceMatcher:
         for match_name, ps in self.match_dict.items():
             patterns = copy.deepcopy(ps["patterns"])
 
+            """
+            allow matching tokens separated by multiple whitespaces
+            they may appear after normalizing nonstandard whitespaces
+            ex. Here␣is␣a\u180E\u200Bproblem." -> "Here␣is␣a␣␣problem."
+            pattern can be preceded and followed by whitespace tokens
+            to keep preceded_by... with and suceeded_by... with match hooks working
+            """
+            if self.allow_multiple_whitespaces:
+                
+                white_pattern = {'IS_SPACE': True, "OP": "*"}
+                
+                normalized_patterns = [white_pattern]
+                for p in patterns:
+                    normalized_patterns+=[p, white_pattern]
+                patterns = normalized_patterns
+            
             # remove custom attributes not supported by spaCy Matcher
             for p in patterns:
                 if "TEMPLATE_ID" in p:

--- a/replacy/__init__.py
+++ b/replacy/__init__.py
@@ -212,7 +212,7 @@ class ReplaceMatcher:
             """
             allow matching tokens separated by multiple whitespaces
             they may appear after normalizing nonstandard whitespaces
-            ex. Here␣is␣a\u180E\u200Bproblem." -> "Here␣is␣a␣␣problem."
+            ex. "Here␣is␣a\u180E\u200Bproblem." -> "Here␣is␣a␣␣problem."
             pattern can be preceded and followed by whitespace tokens
             to keep preceded_by... with and succeeded_by... with match hooks working
             """

--- a/replacy/__init__.py
+++ b/replacy/__init__.py
@@ -61,7 +61,7 @@ class ReplaceMatcher:
         self.nlp = nlp
         self.match_dict = match_dict if match_dict else get_match_dict()
         self.forms_lookup = forms_lookup if forms_lookup else get_forms_lookup()
-        self.allow_multiple_whitespaces  = allow_multiple_whitespaces
+        self.allow_multiple_whitespaces = allow_multiple_whitespaces
 
         self.matcher = Matcher(self.nlp.vocab)
         self._init_matcher()
@@ -217,14 +217,14 @@ class ReplaceMatcher:
             to keep preceded_by... with and suceeded_by... with match hooks working
             """
             if self.allow_multiple_whitespaces:
-                
-                white_pattern = {'IS_SPACE': True, "OP": "*"}
-                
+
+                white_pattern = {"IS_SPACE": True, "OP": "*"}
+
                 normalized_patterns = [white_pattern]
                 for p in patterns:
-                    normalized_patterns+=[p, white_pattern]
+                    normalized_patterns += [p, white_pattern]
                 patterns = normalized_patterns
-            
+
             # remove custom attributes not supported by spaCy Matcher
             for p in patterns:
                 if "TEMPLATE_ID" in p:

--- a/replacy/__init__.py
+++ b/replacy/__init__.py
@@ -234,12 +234,15 @@ class ReplaceMatcher:
             callback = self.get_callback(match_name, match_hooks)
             self.matcher.add(match_name, callback, patterns)
 
-    def __call__(self, sent: str):
+    def __call__(self, sent):
         # self.spans must be cleared - global
         self.spans = []
-        sent_doc = self.nlp(sent)
+        try:
+            sent.text
+        except AttributeError:
+            sent = self.nlp(sent)
 
         # this fills up self.spans
-        matches = self.matcher(sent_doc)
+        matches = self.matcher(sent)
 
         return self.spans

--- a/tests/test_multiple_whitespaces.py
+++ b/tests/test_multiple_whitespaces.py
@@ -9,42 +9,29 @@ nlp = spacy.load("en_core_web_sm")
 # minimal match dict with many whitespaces
 match_dict = {
     "extract-revenge": {
-        "patterns": [
-            {
-                "LEMMA": "extract",
-                "TEMPLATE_ID": 1
-            }
-        ],
-        "suggestions": [
-            [
-                {
-                    "TEXT": "exact",
-                    "FROM_TEMPLATE_ID": 1
-                }
-            ]
-        ],
+        "patterns": [{"LEMMA": "extract", "TEMPLATE_ID": 1}],
+        "suggestions": [[{"TEXT": "exact", "FROM_TEMPLATE_ID": 1}]],
         "match_hook": [
             {
                 "name": "succeeded_by_phrase",
                 "args": "revenge",
-                "match_if_predicate_is": True
+                "match_if_predicate_is": True,
             }
         ],
         "test": {
             "positive": [
-                "And at the same time extract revenge on those he so despises?", # 0
-                "Watch as Tampa Bay extracts  revenge against his former Los Angeles Rams team.", # 1
-                "In fact, the farmer was so mean to this young man he determined to extract   revenge.", # 2
-                "And at the same time extract          revenge on the whites he so despises?", # 10 sic
+                "And at the same time extract revenge on those he so despises?",  # 0
+                "Watch as Tampa Bay extracts  revenge against his former Los Angeles Rams team.",  # 1
+                "In fact, the farmer was so mean to this young man he determined to extract   revenge.",  # 2
+                "And at the same time extract          revenge on the whites he so despises?",  # 10 sic
             ],
-            "negative": [
-                "Mother flavours her custards with lemon extract."
-            ]
-        }
+            "negative": ["Mother flavours her custards with lemon extract."],
+        },
     }
 }
 
 r_matcher = ReplaceMatcher(nlp, match_dict, allow_multiple_whitespaces=True)
+
 
 def test_multiple_whites():
     sents = match_dict["extract-revenge"]["test"]["positive"]

--- a/tests/test_multiple_whitespaces.py
+++ b/tests/test_multiple_whitespaces.py
@@ -1,0 +1,55 @@
+import pytest
+import spacy
+from replacy import ReplaceMatcher
+from replacy.db import get_match_dict
+from functional import seq
+
+nlp = spacy.load("en_core_web_sm")
+
+# minimal match dict with many whitespaces
+match_dict = {
+    "extract-revenge": {
+        "patterns": [
+            {
+                "LEMMA": "extract",
+                "TEMPLATE_ID": 1
+            }
+        ],
+        "suggestions": [
+            [
+                {
+                    "TEXT": "exact",
+                    "FROM_TEMPLATE_ID": 1
+                }
+            ]
+        ],
+        "match_hook": [
+            {
+                "name": "succeeded_by_phrase",
+                "args": "revenge",
+                "match_if_predicate_is": True
+            }
+        ],
+        "test": {
+            "positive": [
+                "And at the same time extract revenge on those he so despises?", # 0
+                "Watch as Tampa Bay extracts  revenge against his former Los Angeles Rams team.", # 1
+                "In fact, the farmer was so mean to this young man he determined to extract   revenge.", # 2
+                "And at the same time extract          revenge on the whites he so despises?", # 10 sic
+            ],
+            "negative": [
+                "Mother flavours her custards with lemon extract."
+            ]
+        }
+    }
+}
+
+r_matcher = ReplaceMatcher(nlp, match_dict, allow_multiple_whitespaces=True)
+
+def test_multiple_whites():
+    sents = match_dict["extract-revenge"]["test"]["positive"]
+    for sent in sents:
+        assert len(r_matcher(sent)), "Should correct with multiple whitespaces"
+
+        suggestion = r_matcher(sent)[0].text.strip()
+        assert "extract" in suggestion, "Should correct with multiple whitespaces"

--- a/tests/test_multiple_whitespaces.py
+++ b/tests/test_multiple_whitespaces.py
@@ -2,7 +2,6 @@ import pytest
 import spacy
 from replacy import ReplaceMatcher
 from replacy.db import get_match_dict
-from functional import seq
 
 nlp = spacy.load("en_core_web_sm")
 

--- a/tests/test_multiple_whitespaces.py
+++ b/tests/test_multiple_whitespaces.py
@@ -1,7 +1,6 @@
 import pytest
 import spacy
 from replacy import ReplaceMatcher
-from replacy.db import get_match_dict
 
 nlp = spacy.load("en_core_web_sm")
 


### PR DESCRIPTION
[ENG-7251]
Allow matching tokens separated by multiple whitespaces

They may appear after normalizing nonstandard whitespaces
ex. `"Here␣is␣a\u180E\u200Bproblem."` -> `"Here␣is␣a␣␣problem."`

pattern can be preceded and followed by whitespace tokens
to keep `preceded_by...` and `succeeded_by...`  match hooks working

[ENG-7251]: https://qordoba.atlassian.net/browse/ENG-7251

edit:
support passing both text and doc (avoiding double conversion)