### PR TITLE
make kenlm not required, add note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ span = r_matcher(doc)[0]
 ReplaCy uses [LemmInflect](https://github.com/bjascob/LemmInflect) inflection module underhood.
 
 Speed and accuracy benchmark (copied from the Lemminflect repo):
-```
+
+```sh
 | Package          | Verb  |  Noun | ADJ/ADV | Overall |  Speed  |
 |----------------------------------------------------------------|
 | LemmInflect      | 96.1% | 95.4% |  93.9%  |  95.6%  | 42.0 uS |
@@ -315,21 +316,21 @@ from replacy.db import load_json
 match_dict = load_json('/path/to/your/match/dict')
 ReplaceMatcher.validate_match_dict(match_dict)
 ```
+
 ## Miscellaneous
 
 ### Suggestions ranking
 
-ReplaCy supports multiple suggestions, which by default are not ranked.
-Ideally, one could use a very performant language model to sort the output.
-Our recommendation: [KenLM](https://github.com/kpu/kenlm).
+ReplaCy supports multiple suggestions, which by default are not ranked. If you would like the suggestions to be sorted, replaCy allows ranking by LM perplexity. Currently, we support one LM: [KenLM](https://github.com/kpu/kenlm).
 
-Load your KenLM model by passing `lm_path`:
+To use this feature, you must first install KenLM from GitHub, using something like `pip install git+https://github.com/kpu/kenlm#egg=kenlm` or `poetry add git+https://github.com/kpu/kenlm@master`, or whatever way you deal with the nightmare that are Python dependencies.
+
+Load your KenLM model by passing `lm_path` when instantiating an instance of `ReplaceMatcher`:
 
 ```python
 lm_path='/path/to/your/kenlm/model.bin'
 rmatcher = ReplaceMatcher(nlp, match_dict=match_dict, lm_path=lm_path)
 ```
-
 
 ### Multiple spaces support
 
@@ -352,7 +353,7 @@ patterns in `match_dict` should have extra whitespace tokens:
 
 ex.
 
-```
+```python
 "patterns": [
                 {
                     "LOWER": "a"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
-spacy==2.2.0
 pytest>=5.3.2
+spacy==2.2.0
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.0/en_core_web_sm-2.2.0.tar.gz
+-e git+https://github.com/kpu/kenlm#egg=kenlm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pyfunctional>=1.2.0
-lemminflect==0.2.1
 jsonschema>=3.2.0
-https://github.com/kpu/kenlm/archive/master.zip
+lemminflect==0.2.1
+pyfunctional>=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,7 @@ setup(
     license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=[
-        "pyfunctional>=1.2.0",
-        "jsonschema>=3.2.0",
-        "lemminflect==0.2.1",
-        "kenlm @ https://github.com/kpu/kenlm/archive/master.zip#egg=kenlm-0.0.0",
-    ],
+    install_requires=["pyfunctional>=1.2.0", "jsonschema>=3.2.0", "lemminflect==0.2.1"],
     python_requires=">=3.5",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Fixes #66 

I tested this locally with pip, both native mac and in Docker. It seems to work in both cases. Since I added KenLM to `requirements-dev.txt`, tests should still pass... and `poetry` installation worked, at least when my `pyproject.toml` looks like this:

```toml
[tool.poetry.dependencies]
python = "^3.7"
qai = "^4.0.5"
en-core-web-sm = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.0/en_core_web_sm-2.3.0.tar.gz#egg=en_core_web_sm==2.3.0" }
kenlm = { git = "https://github.com/kpu/kenlm", rev = "master" }
replacy = { path = "../replacy" }
spacy = "^2.3.0"
```

Edit: GH Actions ran the dev requirements install, and ran tests, and both completed without error... So I think this is the way to go