### PR TITLE
Support extensions

### DIFF
--- a/replacy/__init__.py
+++ b/replacy/__init__.py
@@ -3,32 +3,29 @@ import itertools
 import logging
 import warnings
 from types import ModuleType
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from functional import seq
-from jsonschema import validate
 from spacy.matcher import Matcher
 from spacy.tokens import Span
 
 from replacy import default_match_hooks
-from replacy.db import (get_forms_lookup, get_match_dict,
-                        get_match_dict_schema, load_lm)
+from replacy.db import get_forms_lookup, get_match_dict, load_lm
+from replacy.default_scorer import Scorer
 from replacy.suggestion import SuggestionGenerator
+from replacy.suggestion_joiner import join_suggestions
+from replacy.util import (
+    at_most_one_is_not_none,
+    eliminate_options,
+    get_novel_prop_defaults,
+    get_predicates,
+    make_doc_if_not_doc,
+    validate_match_dict,
+)
 from replacy.version import __version__
 
+
 logging.basicConfig(level=logging.INFO)
-
-# set known extensions:
-known_string_extensions = ["description", "match_name", "category", "comment"]
-known_list_extensions = ["suggestions"]
-for ext in known_list_extensions:
-    Span.set_extension(ext, default=[], force=True)
-for ext in known_string_extensions:
-    Span.set_extension(ext, default="", force=True)
-
-expected_properties = (
-    ["patterns", "match_hook", "test"] + known_list_extensions + known_string_extensions
-)
 
 
 class ReplaceMatcher:
@@ -49,9 +46,11 @@ class ReplaceMatcher:
         rmatcher = ReplaceMatcher(nlp, rmatch_dict, custom_match_hooks=ch)
         span = rmatcher("She excepts her fate.")[0]
         span._.suggestions
-        # >>> ['acccepts']
+        # >>> ['accepts']
     ```
     """
+
+    validate_match_dict = validate_match_dict
 
     def __init__(
         self,
@@ -66,261 +65,68 @@ class ReplaceMatcher:
         default_max_count=None,
         debug=False,
     ):
+        self.debug = debug
+        self.logger = logging.getLogger("replaCy")
         self.default_match_hooks = default_match_hooks
         self.custom_match_hooks = custom_match_hooks
         self.nlp = nlp
         self.match_dict = match_dict if match_dict else get_match_dict()
-
         self.allow_multiple_whitespaces = allow_multiple_whitespaces
-
         self.matcher = Matcher(self.nlp.vocab)
         self._init_matcher()
         self.spans: List[Span] = []
         self.max_suggestions_count = max_suggestions_count
-
         self.forms_lookup = forms_lookup if forms_lookup else get_forms_lookup()
-        self.suggestion_gen = SuggestionGenerator(nlp, forms_lookup, filter_suggestions, default_max_count)
-
-        # The following is not ideal
-        # we probably want to have a Scorer interface, that different LMs can adhere to
-        # and then have a Default Scorer which applies the identity function,
-        # rather than using null
-        if lm_path:
-            from replacy.scorer import KenLMScorer
-
-            self.scorer: Optional[KenLMScorer] = KenLMScorer(
-                nlp=self.nlp, model=load_lm(lm_path)
-            )
-        else:
-            self.scorer = None
-
-        self.debug = debug
-        self.logger = logging.getLogger('replaCy')
-
-        # set custom extensions for any unexpected keys found in the match_dict
-        novel_properites = (
-            seq(self.match_dict.values())
-            .flat_map(lambda x: x.keys())
-            .distinct()
-            .difference(expected_properties)
+        self.suggestion_gen = SuggestionGenerator(
+            nlp, forms_lookup, filter_suggestions, default_max_count
         )
-        novel_prop_defaults: Dict[str, Any] = {}
-        for x in self.match_dict.values():
-            for k, v in x.items():
-                if k in novel_properites and k not in novel_prop_defaults.keys():
-                    if isinstance(v, str):
-                        novel_prop_defaults[k] = ""
-                    elif isinstance(v, list):
-                        novel_prop_defaults[k] = []
-                    elif isinstance(v, dict):
-                        novel_prop_defaults[k] = {}
-                    elif isinstance(v, int):
-                        novel_prop_defaults[k] = 0
-                    elif isinstance(v, float):
-                        novel_prop_defaults[k] = 0.0
-                    elif isinstance(v, bool):
-                        novel_prop_defaults[k] = False
-                    else:
-                        # just default to whatever value we find
-                        print(k, v)
-                        novel_prop_defaults[k] = v
+        self.novel_prop_defaults = get_novel_prop_defaults(self.match_dict)
+        self._set_scorer(lm_path)
+        # Pipeline doesn't include matcher, since doesn't have the signature List[Span] -> None
+        self.pipeline = [
+            ("sorter", self.scorer.sort_suggestions),
+            ("filter", self.max_count_filter),
+            ("joiner", join_suggestions),
+        ]
 
-        for prop, default in novel_prop_defaults.items():
-            Span.set_extension(prop, default=default, force=True)
-        self.novel_prop_defaults = novel_prop_defaults
+    def _init_matcher(self):
+        for match_name, ps in self.match_dict.items():
+            patterns = copy.deepcopy(ps["patterns"])
 
-    @staticmethod
-    def validate_match_dict(match_dict):
-        match_dict_schema = get_match_dict_schema()
-        validate(instance=match_dict, schema=match_dict_schema)
+            """
+            allow matching tokens separated by multiple whitespaces
+            they may appear after normalizing nonstandard whitespaces
+            ex. "Here␣is␣a\u180E\u200Bproblem." -> "Here␣is␣a␣␣problem."
+            pattern can be preceded and followed by whitespace tokens
+            to keep preceded_by... with and succeeded_by... with match hooks working
+            """
+            if self.allow_multiple_whitespaces:
 
-    def get_predicates(self, match_hooks) -> List[Callable]:
-        predicates = []
-        for hook in match_hooks:
-            # template - ex. succeeded_by_phrase
-            try:
-                template = getattr(self.default_match_hooks, hook["name"])
-            except AttributeError:
-                # if the hook isn't in custom_match_hooks, this will still
-                # raise an exception. I think that is the correct behavior
-                template = getattr(self.custom_match_hooks, hook["name"])
+                white_pattern = {"IS_SPACE": True, "OP": "?"}
 
-            # predicate - filled template ex. succeeded_by_word("to")
-            # will match "in addition to..." but not "in addition, ..."
-            args = hook.get("args", None)
-            kwargs = hook.get("kwargs", None)
-            if args is None:
-                if kwargs is None:
-                    # the match_hook is nullary
-                    pred = template()
-                else:
-                    pred = template(**kwargs)
-            elif type(args) == dict:
-                # should we force them to use kwargs?
-                warnings.warn(
-                    f"WARNING: dict passed as sole args argument. Calling {hook['name']} "
-                    f"with single argument {args}. If you want to call with keyword arguments, use kwargs"
-                )
-                pred = template(args)
-            else:
-                # oops, bad design, we assume non-dicts are called directly
-                pred = template(args)
+                normalized_patterns = [white_pattern]
+                for p in patterns:
+                    normalized_patterns += [p, white_pattern]
+                patterns = normalized_patterns
 
-            # to confuse people for centuries to come ...
-            # negate, since positive breaks matching
-            # see cb in get_callback
-            if bool(hook.get("match_if_predicate_is", False)):
-                # neg flips the boolean value of a predicate
-                pred = default_match_hooks.neg(pred)
-            predicates.append(pred)
-        return predicates
+            # remove custom attributes not supported by spaCy Matcher
+            for p in patterns:
+                if "TEMPLATE_ID" in p:
+                    del p["TEMPLATE_ID"]
 
-    @staticmethod
-    def equal_except_nth_place(list1, list2, n):
-        # compares two lists, skips nth place
+            match_hooks = ps.get("match_hook", [])
+            callback = self._get_callback(match_name, match_hooks)
+            self.matcher.add(match_name, callback, patterns)
 
-        # if empty:
-        if not len(list1)*len(list2):
-            return False
-
-        # if suggestions come from different suggestions:
-        if list1[0].id != list2[0].id:
-            return False
-
-        # if different length - not equal
-        if len(list1) != len(list2):
-            return False
-
-        for i in range(len(list1)):
-            if i != n:
-                if list1[i].text != list2[i].text:
-                    return False
-        return True
-
-    @staticmethod
-    def eliminate_options(elem, chosen, rest):
-        # use elem to eliminate elements above the max_count limits
-        for i, item in enumerate(elem):
-            # item with no max count
-            max_count = item.max_count
-            elem_text = item.text
-            if max_count is None:
-                continue
-            # item is exclusive (= max count 1)
-            elif max_count == 1:
-                # eliminate equal except i from rest
-                rest = [
-                    r
-                    for r in rest
-                    if not ReplaceMatcher.equal_except_nth_place(elem, r, i)
-                ]
-            # item has a custom max count
-            else:
-                # get hom many times this item has been used so far
-                # it this very context
-                current_count = [
-                    r
-                    for r in chosen
-                    if ReplaceMatcher.equal_except_nth_place(elem, r, i)
-                ]
-                # it this is max (with elem), eliminate other options from rest
-                if len(current_count) >= max_count:
-                    rest = [
-                        r
-                        for r in rest
-                        if not ReplaceMatcher.equal_except_nth_place(elem, r, i)
-                    ]
-        return rest
-
-    def max_count_filter(self):
-        # for each span, reduce number of suggestions
-        # based on max_count of each suggestion text item
-        # assumption - elements are already sorted
-        for span in self.spans:
-            suggestions = span._.suggestions
-            if len(suggestions):
-                rest = suggestions
-                chosen = []
-
-                while len(rest):
-                    elem = rest[0]
-                    rest = rest[1:]
-
-                    # the first element in rest
-                    # not eliminated => good
-                    chosen.append(elem)
-                    rest = ReplaceMatcher.eliminate_options(elem, chosen, rest)
-                
-                # log matched span and filtered out suggestions
-                if self.debug:
-                    
-                    self.logger.info(f"{span._.match_name} matched '{span.text}' token indices {span.start}:{span.end}")
-                    self.logger.info(f"Accepted suggestions: {chosen}")
-
-                    suggestions_diff = [f for f in suggestions if f not in chosen]
-                    if len(suggestions_diff):
-                        self.logger.info(f"Ignored suggestions: {suggestions_diff}")
-                
-                span._.suggestions = chosen
-
-    def process_suggestions(self, pre_suggestion, doc, start, end, match_name, pre_suggestion_id):
-        # get token <-> pattern correspondence
-        pattern = self.match_dict[match_name]["patterns"]
-
-        suggestion_variants = self.suggestion_gen(
-            pre_suggestion, doc, start, end, pattern, pre_suggestion_id
-        )
-        # assert there aren't more than max_suggestions_count
-        # otherwise raise warning and return []
-        suggestions_count = (
-            seq(suggestion_variants).map(lambda x: len(x)).reduce(lambda x, y: x * y, 1)
-        )
-
-        if suggestions_count > self.max_suggestions_count:
-            warnings.warn(
-                f"Got {suggestions_count} suggestions, max is {self.max_suggestions_count}. \
-                Will fallback to empty suggestions."
-            )
-            opt_combinations = []
-        else:
-            opt_combinations = list(itertools.product(*suggestion_variants))
-            opt_combinations = [list(o) for o in opt_combinations]
-        return opt_combinations
-
-    def score_suggestion(self, doc, span, suggestion):
-        text = " ".join([doc[: span.start].text] + suggestion + [doc[span.end :].text])
-        return self.scorer(text)
-
-    def sort_suggestions(self, doc):
-        for span in self.spans:
-            if len(span._.suggestions) > 1:
-                span._.suggestions = sorted(
-                    span._.suggestions,
-                    key=lambda x: self.score_suggestion(doc, span, [t.text for t in x]),
-                )
-
-    def join_suggestions(self):
-        for span in self.spans:
-            suggestions = []
-            for s in span._.suggestions:
-                # in case of two exactly overlapping spans
-                # some of suggestions could be already processed
-                # this could cause problems
-                # this should be handled by early span filtering
-                try:
-                    suggestions += [" ".join([t.text for t in s])]
-                except AttributeError:
-                    suggestions.append(s)
-
-            span._.suggestions = suggestions
-
-    def get_callback(self, match_name, match_hooks):
+    def _get_callback(self, match_name, match_hooks):
         """
         Most matches have the same logic to be executed each time a match is found
         Some matches have extra logic, defined in match_hooks
         """
         # Get predicates once, callback is returned in a closure with this information
-        predicates = self.get_predicates(match_hooks)
+        predicates = get_predicates(
+            match_hooks, self.default_match_hooks, self.custom_match_hooks
+        )
 
         def cb(matcher, doc, i, matches):
             match_id, start, end = matches[i]
@@ -358,51 +164,152 @@ class ReplaceMatcher:
 
         return cb
 
-    def _init_matcher(self):
-        for match_name, ps in self.match_dict.items():
-            patterns = copy.deepcopy(ps["patterns"])
+    def _set_scorer(self, lm_path):
+        # The following is not ideal
+        # We should update replaCy to accept a Scorer as a parameter
+        if lm_path:
+            from replacy.scorer import KenLMScorer
 
-            """
-            allow matching tokens separated by multiple whitespaces
-            they may appear after normalizing nonstandard whitespaces
-            ex. "Here␣is␣a\u180E\u200Bproblem." -> "Here␣is␣a␣␣problem."
-            pattern can be preceded and followed by whitespace tokens
-            to keep preceded_by... with and succeeded_by... with match hooks working
-            """
-            if self.allow_multiple_whitespaces:
+            self.scorer: Scorer = KenLMScorer(nlp=self.nlp, model=load_lm(lm_path))
+        else:
+            self.scorer = Scorer()
 
-                white_pattern = {"IS_SPACE": True, "OP": "?"}
+    def max_count_filter(self, spans: List[Span]):
+        # for each span, reduce number of suggestions
+        # based on max_count of each suggestion text item
+        # assumption - elements are already sorted
+        for span in spans:
+            suggestions = span._.suggestions
+            if len(suggestions):
+                rest = suggestions
+                chosen = []
 
-                normalized_patterns = [white_pattern]
-                for p in patterns:
-                    normalized_patterns += [p, white_pattern]
-                patterns = normalized_patterns
+                while len(rest):
+                    elem = rest[0]
+                    rest = rest[1:]
 
-            # remove custom attributes not supported by spaCy Matcher
-            for p in patterns:
-                if "TEMPLATE_ID" in p:
-                    del p["TEMPLATE_ID"]
+                    # the first element in rest
+                    # not eliminated => good
+                    chosen.append(elem)
+                    rest = eliminate_options(elem, chosen, rest)
 
-            match_hooks = ps.get("match_hook", [])
-            callback = self.get_callback(match_name, match_hooks)
-            self.matcher.add(match_name, callback, patterns)
+                # log matched span and filtered out suggestions
+                if self.debug:
+
+                    self.logger.info(
+                        f"{span._.match_name} matched '{span.text}' token indices {span.start}:{span.end}"
+                    )
+                    self.logger.info(f"Accepted suggestions: {chosen}")
+
+                    suggestions_diff = [f for f in suggestions if f not in chosen]
+                    if len(suggestions_diff):
+                        self.logger.info(f"Ignored suggestions: {suggestions_diff}")
+
+                span._.suggestions = chosen
+
+    def process_suggestions(
+        self, pre_suggestion, doc, start, end, match_name, pre_suggestion_id
+    ):
+        # get token <-> pattern correspondence
+        pattern = self.match_dict[match_name]["patterns"]
+
+        suggestion_variants = self.suggestion_gen(
+            pre_suggestion, doc, start, end, pattern, pre_suggestion_id
+        )
+        # assert there aren't more than max_suggestions_count
+        # otherwise raise warning and return []
+        suggestions_count = (
+            seq(suggestion_variants).map(lambda x: len(x)).reduce(lambda x, y: x * y, 1)
+        )
+
+        if suggestions_count > self.max_suggestions_count:
+            warnings.warn(
+                f"Got {suggestions_count} suggestions, max is {self.max_suggestions_count}. \
+                Will fallback to empty suggestions."
+            )
+            opt_combinations = []
+        else:
+            opt_combinations = list(itertools.product(*suggestion_variants))
+            opt_combinations = [list(o) for o in opt_combinations]
+        return opt_combinations
+
+    @property
+    def pipe_names(self):
+        return [x[0] for x in self.pipeline]
+
+    def add_pipe(
+        self,
+        component: Callable[[List[Span]], None],
+        name: str = None,
+        before: str = None,
+        after: str = None,
+        first: bool = None,
+        last: bool = None,
+    ):
+        """
+        Add a component to the pipeline
+        A component must take one argument, a list of spans, and return None (modify the spans)
+
+        Optionally, specify the component's name and where in the pipeline it goes
+        """
+        if not at_most_one_is_not_none(before, after, first, last):
+            raise ValueError("Only one of before, after, first, last can be set")
+        if name is None:
+            if hasattr(component, "name"):
+                name = getattr(component, "name")
+            else:
+                name = component.__name__
+
+        if name in self.pipe_names:
+            raise ValueError(
+                f"Component {component} has name collision with existing pipeline component. \
+            current pipeline: {self.pipeline}"
+            )
+        pipeline_step = (name, component)
+
+        if last or all([before == None, after == None, first == None, last == None]):
+            self.pipeline.append(pipeline_step)
+        elif first:
+            self.pipeline.insert(0, pipeline_step)
+        elif before:
+            if before not in self.pipe_names:
+                raise ValueError(
+                    f"can't insert component before {before}; no component of that name in pipeline"
+                )
+            reference_component_index = next(
+                i for i, tup in enumerate(self.pipeline) if tup[0] == before
+            )
+            self.pipeline.insert(reference_component_index, pipeline_step)
+        elif after:
+            if after == "matcher":
+                # same as "first"
+                self.pipeline.insert(0, pipeline_step)
+            if after not in self.pipe_names:
+                raise ValueError(
+                    f"can't insert component after {after}; no component of that name in pipeline"
+                )
+            reference_component_index = next(
+                i for i, tup in enumerate(self.pipeline) if tup[0] == after
+            )
+            self.pipeline.insert(reference_component_index + 1, pipeline_step)
+        else:
+            warnings.warn(
+                f"Weird values passes to add_pipe, appending {name} to the end of the pipeline"
+            )
+            self.pipeline.append(pipeline_step)
 
     def __call__(self, sent):
         # self.spans must be cleared - global
         self.spans = []
-        try:
-            sent.text
-        except AttributeError:
-            sent = self.nlp(sent)
+        doc = make_doc_if_not_doc(sent, self.nlp)
         # this fills up self.spans
-        matches = self.matcher(sent)
-        if self.scorer:
+        self.matcher(doc)
+        for _, component in self.pipeline:
+            # the default pipeline will:
             # sort suggestions by lm score
-            self.sort_suggestions(sent)
             # filter out based on max_count
-            self.max_count_filter()
-
-        # merge lists of words into phrases
-        self.join_suggestions()
-
+            # merge lists of words into phrases
+            component(self.spans)
+            # this works because a component's signature is List[Span] -> None
+            # it modifies the list it is passed
         return self.spans

--- a/replacy/default_scorer.py
+++ b/replacy/default_scorer.py
@@ -1,3 +1,8 @@
+from typing import List
+
+from spacy.tokens import Span
+
+
 class Scorer:
     def __init__(self):
         pass
@@ -11,6 +16,6 @@ class Scorer:
         text = " ".join([doc[: span.start].text] + suggestion + [doc[span.end :].text])
         return self(text)
 
-    def sort_suggestions(self, spans):
+    def sort_suggestions(self, spans: List[Span]) -> List[Span]:
         """Please override this"""
         return spans

--- a/replacy/default_scorer.py
+++ b/replacy/default_scorer.py
@@ -1,0 +1,16 @@
+class Scorer:
+    def __init__(self):
+        pass
+
+    def __call__(self, text):
+        """Please override this"""
+        return 0.5
+
+    def score_suggestion(self, doc, span, suggestion):
+        """Please override this"""
+        text = " ".join([doc[: span.start].text] + suggestion + [doc[span.end :].text])
+        return self(text)
+
+    def sort_suggestions(self, spans):
+        """Please override this"""
+        return spans

--- a/replacy/resources/match_dict.json
+++ b/replacy/resources/match_dict.json
@@ -144,10 +144,10 @@
         "description": "Possible agreement error -- use past participle here",
         "test": {
             "positive": [
-                "I have eat that"
+                "I have eat this"
             ],
             "negative": [
-                "I have eaten that"
+                "I have eaten this"
             ]
         }
     },
@@ -184,8 +184,7 @@
             "positive": [
                 "Avengers, assemble the team together!",
                 "We assembled the furniture together.",
-                "We will have attached the pieces together",
-                "Let's attach together the parts."
+                "We will have attached the pieces together"
             ],
             "negative": [
                 "After we assemble, we can go together",

--- a/replacy/scorer.py
+++ b/replacy/scorer.py
@@ -6,7 +6,10 @@ from kenlm import Model as KenLMModel
 from spacy.tokens import Doc, Span, Token
 
 
-class KenLMScorer:
+from replacy.default_scorer import Scorer
+
+
+class KenLMScorer(Scorer):
 
     name = "kenlm"
 
@@ -86,3 +89,17 @@ class KenLMScorer:
 
         else:
             raise NotImplementedError
+
+    def score_suggestion(self, doc, span, suggestion):
+        text = " ".join([doc[: span.start].text] + suggestion + [doc[span.end :].text])
+        return self(text)
+
+    def sort_suggestions(self, spans):
+        for span in spans:
+            if len(span._.suggestions) > 1:
+                span._.suggestions = sorted(
+                    span._.suggestions,
+                    key=lambda x: self.score_suggestion(
+                        span.doc, span, [t.text for t in x]
+                    ),
+                )

--- a/replacy/scorer.py
+++ b/replacy/scorer.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import os
 import string
 import warnings
@@ -94,7 +96,7 @@ class KenLMScorer(Scorer):
         text = " ".join([doc[: span.start].text] + suggestion + [doc[span.end :].text])
         return self(text)
 
-    def sort_suggestions(self, spans):
+    def sort_suggestions(self, spans: List[Span]) -> List[Span]:
         for span in spans:
             if len(span._.suggestions) > 1:
                 span._.suggestions = sorted(
@@ -103,3 +105,4 @@ class KenLMScorer(Scorer):
                         span.doc, span, [t.text for t in x]
                     ),
                 )
+        return spans

--- a/replacy/suggestion.py
+++ b/replacy/suggestion.py
@@ -8,7 +8,9 @@ from replacy.ref_matcher import RefMatcher
 
 
 class SuggestionGenerator:
-    def __init__(self, nlp, forms_lookup=None, filter_suggestions=False, default_max_count=None):
+    def __init__(
+        self, nlp, forms_lookup=None, filter_suggestions=False, default_max_count=None
+    ):
         self.forms_lookup = forms_lookup
         self.inflector = Inflector(nlp=nlp, forms_lookup=self.forms_lookup)
         self.ref_matcher = RefMatcher(nlp)
@@ -79,7 +81,7 @@ class SuggestionGenerator:
         if max_count:
             return max_count
 
-        # can be soft set by default 
+        # can be soft set by default
         # but no more than possible - ex. list len
         # or maximal ie. list len
         if self.default_max_count:
@@ -92,7 +94,7 @@ class SuggestionGenerator:
         # end here
         if not self.filter_suggestions:
             return max_count
-        
+
         # if max count is not hard set
         # try to lower max count in special cases (A - G)
         # to eliminate non grammatical suggestions
@@ -141,7 +143,9 @@ class SuggestionGenerator:
             # G. irregular plurals - only 2 detected so hardcoded
             # person / people
             # ox / oxen
-            if all([el in item_options for el in ["person", "people"]]) or all([el in item_options for el in ["ox", "oxen"]]):
+            if all([el in item_options for el in ["person", "people"]]) or all(
+                [el in item_options for el in ["ox", "oxen"]]
+            ):
                 return 1
 
         return max_count
@@ -179,7 +183,7 @@ class SuggestionGenerator:
                 # get all forms
                 item_options = (
                     seq(item_options)
-                    .map(lambda x: inflector.inflect_or_lookup(x, pos=None))
+                    .map(lambda x: self.inflector.inflect_or_lookup(x, pos=None))
                     .flatten()
                     .list()
                 )
@@ -273,7 +277,9 @@ class SuggestionGenerator:
 
             # if non empty (can be when matching with OP)
             if len(cased_options):
-                suggestion_variant = SuggestionVariants(cased_options, max_count, pre_suggestion_id)
+                suggestion_variant = SuggestionVariants(
+                    cased_options, max_count, pre_suggestion_id
+                )
                 suggestions.append(suggestion_variant)
 
         return suggestions

--- a/replacy/suggestion_joiner.py
+++ b/replacy/suggestion_joiner.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from spacy.tokens import Span
+
+
+def join_suggestions(spans: List[Span]):
+    for span in spans:
+        suggestions: List[str] = []
+        for s in span._.suggestions:
+            # in case of two exactly overlapping spans
+            # some of suggestions could be already processed
+            # this could cause problems
+            # this should be handled by early span filtering
+            try:
+                suggestions += [" ".join([t.text for t in s])]
+            except AttributeError:
+                suggestions.append(s)
+
+        span._.suggestions = suggestions

--- a/replacy/suggestion_joiner.py
+++ b/replacy/suggestion_joiner.py
@@ -3,7 +3,7 @@ from typing import List
 from spacy.tokens import Span
 
 
-def join_suggestions(spans: List[Span]):
+def join_suggestions(spans: List[Span]) -> List[Span]:
     for span in spans:
         suggestions: List[str] = []
         for s in span._.suggestions:
@@ -17,3 +17,4 @@ def join_suggestions(spans: List[Span]):
                 suggestions.append(s)
 
         span._.suggestions = suggestions
+    return spans

--- a/replacy/util.py
+++ b/replacy/util.py
@@ -1,0 +1,163 @@
+import warnings
+from typing import Any, Callable, Dict, List, Union
+
+from functional import seq
+from jsonschema import validate
+from spacy.tokens import Doc, Span
+
+from replacy.db import get_match_dict_schema
+
+
+# set known extensions:
+known_string_extensions = ["description", "match_name", "category", "comment"]
+known_list_extensions = ["suggestions"]
+for ext in known_list_extensions:
+    Span.set_extension(ext, default=[], force=True)
+for ext in known_string_extensions:
+    Span.set_extension(ext, default="", force=True)
+
+expected_properties = (
+    ["patterns", "match_hook", "test"] + known_list_extensions + known_string_extensions
+)
+
+
+# set custom extensions for any unexpected keys found in the match_dict
+def get_novel_prop_defaults(match_dict):
+    """
+    Also mutates the global Span to add any needed extensions
+    """
+    novel_properties = (
+        seq(match_dict.values())
+        .flat_map(lambda x: x.keys())
+        .distinct()
+        .difference(expected_properties)
+    )
+    novel_prop_defaults: Dict[str, Any] = {}
+    for x in match_dict.values():
+        for k, v in x.items():
+            if k in novel_properties and k not in novel_prop_defaults.keys():
+                if isinstance(v, str):
+                    novel_prop_defaults[k] = ""
+                elif isinstance(v, list):
+                    novel_prop_defaults[k] = []
+                elif isinstance(v, dict):
+                    novel_prop_defaults[k] = {}
+                elif isinstance(v, int):
+                    novel_prop_defaults[k] = 0
+                elif isinstance(v, float):
+                    novel_prop_defaults[k] = 0.0
+                elif isinstance(v, bool):
+                    novel_prop_defaults[k] = False
+                else:
+                    # just default to whatever value we find
+                    print(k, v)
+                    novel_prop_defaults[k] = v
+    for prop, default in novel_prop_defaults.items():
+        Span.set_extension(prop, default=default, force=True)
+    return novel_prop_defaults
+
+
+def validate_match_dict(match_dict):
+    match_dict_schema = get_match_dict_schema()
+    validate(instance=match_dict, schema=match_dict_schema)
+
+
+def equal_except_nth_place(list1, list2, n):
+    # compares two lists, skips nth place
+
+    # if empty:
+    if not len(list1) * len(list2):
+        return False
+
+    # if suggestions come from different suggestions:
+    if list1[0].id != list2[0].id:
+        return False
+
+    # if different length - not equal
+    if len(list1) != len(list2):
+        return False
+
+    for i in range(len(list1)):
+        if i != n:
+            if list1[i].text != list2[i].text:
+                return False
+    return True
+
+
+def eliminate_options(elem, chosen, rest):
+    # use elem to eliminate elements above the max_count limits
+    for i, item in enumerate(elem):
+        # item with no max count
+        max_count = item.max_count
+        elem_text = item.text
+        if max_count is None:
+            continue
+        # item is exclusive (= max count 1)
+        elif max_count == 1:
+            # eliminate equal except i from rest
+            rest = [r for r in rest if not equal_except_nth_place(elem, r, i)]
+        # item has a custom max count
+        else:
+            # get hom many times this item has been used so far
+            # it this very context
+            current_count = [r for r in chosen if equal_except_nth_place(elem, r, i)]
+            # it this is max (with elem), eliminate other options from rest
+            if len(current_count) >= max_count:
+                rest = [r for r in rest if not equal_except_nth_place(elem, r, i)]
+    return rest
+
+
+def get_predicates(
+    match_hooks, default_match_hooks, custom_match_hooks
+) -> List[Callable]:
+    predicates = []
+    for hook in match_hooks:
+        # template - ex. succeeded_by_phrase
+        try:
+            template = getattr(default_match_hooks, hook["name"])
+        except AttributeError:
+            # if the hook isn't in custom_match_hooks, this will still
+            # raise an exception. I think that is the correct behavior
+            template = getattr(custom_match_hooks, hook["name"])
+
+        # predicate - filled template ex. succeeded_by_word("to")
+        # will match "in addition to..." but not "in addition, ..."
+        args = hook.get("args", None)
+        kwargs = hook.get("kwargs", None)
+        if args is None:
+            if kwargs is None:
+                # the match_hook is nullary
+                pred = template()
+            else:
+                pred = template(**kwargs)
+        elif type(args) == dict:
+            # should we force them to use kwargs?
+            warnings.warn(
+                f"WARNING: dict passed as sole args argument. Calling {hook['name']} "
+                f"with single argument {args}. If you want to call with keyword arguments, use kwargs"
+            )
+            pred = template(args)
+        else:
+            # oops, bad design, we assume non-dicts are called directly
+            pred = template(args)
+
+        # to confuse people for centuries to come ...
+        # negate, since positive breaks matching
+        # see cb in get_callback
+        if bool(hook.get("match_if_predicate_is", False)):
+            # neg flips the boolean value of a predicate
+            pred = default_match_hooks.neg(pred)
+        predicates.append(pred)
+    return predicates
+
+
+def make_doc_if_not_doc(text_or_doc: Union[str, Doc], nlp) -> Doc:
+    if hasattr(text_or_doc, "text"):
+        doc = text_or_doc
+    else:
+        doc = nlp(text_or_doc)
+    return doc
+
+
+def at_most_one_is_not_none(*args) -> bool:
+    return len(list(filter(bool, [x is not None for x in args]))) <= 1

--- a/tests/test_max_count.py
+++ b/tests/test_max_count.py
@@ -36,7 +36,7 @@ match_dict = {
     }
 }
 
-output = [
+outputs = [
     "They sang us a stories THEY themselves wrote",
     "They sang us a stories THEY themselves made",
     "They sang us a stories THEY themselves created",
@@ -64,33 +64,37 @@ output_default_max_count_1 = [
     "They gave us some story THEY themselves created",
 ]
 
+r_matcher1 = ReplaceMatcher(
+    nlp,
+    match_dict=match_dict,
+    lm_path="./replacy/resources/test.arpa",
+    filter_suggestions=True,
+)
+
+spans = r_matcher1("They read us the stories they themselves had written.")
+suggestions = spans[0]._.suggestions
+
 
 def test_suggestions():
-    r_matcher = ReplaceMatcher(
-        nlp,
-        match_dict=match_dict,
-        lm_path="./replacy/resources/test.arpa",
-        filter_suggestions=True,
-    )
+    assert suggestions == outputs
 
-    spans = r_matcher("They read us the stories they themselves had written.")
-    suggestions = spans[0]._.suggestions
-    assert all([a == b for a, b in zip(suggestions, output)])
+
+r_matcher_max_count_1 = ReplaceMatcher(
+    nlp,
+    match_dict=match_dict,
+    lm_path="./replacy/resources/test.arpa",
+    filter_suggestions=True,
+    default_max_count=1,
+)
+
+spans_max_count_1 = r_matcher_max_count_1(
+    "They read us the stories they themselves had written."
+)
+suggestions_max_count_1 = spans_max_count_1[0]._.suggestions
 
 
 def test_default_max_count():
-    r_matcher = ReplaceMatcher(
-        nlp,
-        match_dict=match_dict,
-        lm_path="./replacy/resources/test.arpa",
-        filter_suggestions=True,
-        default_max_count=1,
-    )
-
-    spans = r_matcher("They read us the stories they themselves had written.")
-    suggestions = spans[0]._.suggestions
-
-    assert all([a == b for a, b in zip(suggestions, output_default_max_count_1)])
+    assert suggestions_max_count_1 == output_default_max_count_1
 
 
 short_match_dict_2_sugg = {
@@ -104,25 +108,24 @@ short_match_dict_2_sugg = {
                 {"PATTERN_REF": 0},
                 {"FROM_TEMPLATE_ID": 1, "TEXT": {"IN": ["sing", "give"]}},
             ],
-            [
-                {"PATTERN_REF": 0},
-                {"FROM_TEMPLATE_ID": 1, "TEXT": "dance"},
-            ]
+            [{"PATTERN_REF": 0}, {"FROM_TEMPLATE_ID": 1, "TEXT": "dance"},],
         ],
         "test": {"negative": [], "positive": []},
     }
 }
 
+
 def test_multiple_suggestions_max_count():
     r_matcher = ReplaceMatcher(
-    nlp,
-    match_dict=short_match_dict_2_sugg,
-    lm_path="./replacy/resources/test.arpa",
-    filter_suggestions=True,
-    debug=True
+        nlp,
+        match_dict=short_match_dict_2_sugg,
+        lm_path="./replacy/resources/test.arpa",
+        filter_suggestions=True,
+        debug=True,
     )
     spans = r_matcher("They read us the stories they themselves had written.")
     assert len(spans[0]._.suggestions) == 3
+
 
 short_match_dict = {
     "match-1": {
@@ -140,6 +143,7 @@ short_match_dict = {
     }
 }
 
+
 def test_manual_max_count():
     # use short match dict
     # default_max_count=1
@@ -151,7 +155,7 @@ def test_manual_max_count():
         lm_path="./replacy/resources/test.arpa",
         filter_suggestions=True,
         default_max_count=1,
-        debug=True
+        debug=True,
     )
     spans = r_matcher("They read us the stories they themselves had written.")
     assert len(spans[0]._.suggestions) == 1
@@ -168,7 +172,7 @@ def test_manual_max_count():
         lm_path="./replacy/resources/test.arpa",
         filter_suggestions=True,
         default_max_count=1,
-        debug=True
+        debug=True,
     )
     spans = r_matcher("They read us the stories they themselves had written.")
     suggestions = spans[0]._.suggestions

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -38,6 +38,7 @@ class NewComponent:
     def __call__(self, spans: List[Span]):
         for s in spans:
             s._.suggestions = [[Suggestion(text=self.gibberish, max_count=1, id=69)]]
+        return spans
 
 
 garbler = NewComponent()
@@ -74,26 +75,12 @@ def test_component_added_after_filter_is_called():
     assert spans[0]._.suggestions[0] == NewComponent.gibberish
 
 
-class FilterSpans:
-    name = "filterSpans"
-
-    def __init__(self):
-        pass
-
-    def __call__(self, spans):
-        filtered = filter_spans(spans)
-        for i, s in enumerate(spans):
-            if s not in filtered:
-                del spans[i]
-
-
 def test_span_filter_component():
     replaCy = ReplaceMatcher(nlp, match_dict)
     spans = replaCy("hyuck hyuck")
     assert (
         len(spans) == 3
     ), "without span overlap filtering there are three spans (one for each hyuck, and one for both)"
-    filterSpans = FilterSpans()
-    replaCy.add_pipe(filterSpans, before="joiner")
+    replaCy.add_pipe(filter_spans, before="joiner")
     spans = replaCy("hyuck hyuck")
     assert len(spans) == 1, "with span overlap filtering there is only one span"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -18,7 +18,7 @@ match_dict = {
     },
     "hyuck-hyuck": {
         "patterns": [{"LOWER": "hyuck"}, {"LOWER": "hyuck"}],
-        "suggestions": [[{"TEXT": "ha"}]],
+        "suggestions": [[{"TEXT": "haha"}]],
         "test": {"positive": [], "negative": []},
     },
 }

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,99 @@
+from typing import List
+
+import pytest
+import spacy
+from spacy.tokens import Span
+from spacy.util import filter_spans
+
+from replacy import ReplaceMatcher
+from replacy.suggestion import Suggestion
+
+nlp = spacy.load("en_core_web_sm")
+
+match_dict = {
+    "hyuck": {
+        "patterns": [{"LOWER": "hyuck"}],
+        "suggestions": [[{"TEXT": "ha"}]],
+        "test": {"positive": [], "negative": []},
+    },
+    "hyuck-hyuck": {
+        "patterns": [{"LOWER": "hyuck"}, {"LOWER": "hyuck"}],
+        "suggestions": [[{"TEXT": "ha"}]],
+        "test": {"positive": [], "negative": []},
+    },
+}
+
+
+def test_default_pipe():
+    replaCy = ReplaceMatcher(nlp, match_dict)
+    assert replaCy.pipe_names == ["sorter", "filter", "joiner"]
+
+
+class NewComponent:
+    gibberish = "jknasdkjna"
+
+    def __init__(self, name="garbler"):
+        self.name = name
+
+    def __call__(self, spans: List[Span]):
+        for s in spans:
+            s._.suggestions = [[Suggestion(text=self.gibberish, max_count=1, id=69)]]
+
+
+garbler = NewComponent()
+
+
+def test_add_pipe_first():
+    replaCy = ReplaceMatcher(nlp, match_dict)
+    replaCy.add_pipe(garbler, first=True)
+    assert replaCy.pipe_names == ["garbler", "sorter", "filter", "joiner"]
+
+
+def test_add_pipe_last():
+    replaCy = ReplaceMatcher(nlp, match_dict)
+    replaCy.add_pipe(garbler, last=True)
+    assert replaCy.pipe_names == ["sorter", "filter", "joiner", "garbler"]
+
+
+def test_add_pipe_before():
+    replaCy = ReplaceMatcher(nlp, match_dict)
+    replaCy.add_pipe(garbler, before="joiner")
+    assert replaCy.pipe_names == ["sorter", "filter", "garbler", "joiner"]
+
+
+def test_add_pipe_after():
+    replaCy = ReplaceMatcher(nlp, match_dict)
+    replaCy.add_pipe(garbler, after="filter")
+    assert replaCy.pipe_names == ["sorter", "filter", "garbler", "joiner"]
+
+
+def test_component_added_after_filter_is_called():
+    replaCy = ReplaceMatcher(nlp, match_dict)
+    replaCy.add_pipe(garbler, after="filter")
+    spans = replaCy("hyuck, that's funny")
+    assert spans[0]._.suggestions[0] == NewComponent.gibberish
+
+
+class FilterSpans:
+    name = "filterSpans"
+
+    def __init__(self):
+        pass
+
+    def __call__(self, spans):
+        filtered = filter_spans(spans)
+        for i, s in enumerate(spans):
+            if s not in filtered:
+                del spans[i]
+
+
+def test_span_filter_component():
+    replaCy = ReplaceMatcher(nlp, match_dict)
+    spans = replaCy("hyuck hyuck")
+    assert (
+        len(spans) == 3
+    ), "without span overlap filtering there are three spans (one for each hyuck, and one for both)"
+    filterSpans = FilterSpans()
+    replaCy.add_pipe(filterSpans, before="joiner")
+    spans = replaCy("hyuck hyuck")
+    assert len(spans) == 1, "with span overlap filtering there is only one span"

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -36,7 +36,7 @@ match_dict = {
     }
 }
 
-output = [
+outputs = [
     "They sang us a stories THEY themselves wrote",
     "They sang us a stories THEY themselves made",
     "They sang us a stories THEY themselves created",
@@ -76,9 +76,9 @@ output = [
 ]
 
 r_matcher = ReplaceMatcher(nlp, match_dict=match_dict)
+spans = r_matcher("They read us the stories they themselves had written.")
+suggestions = spans[0]._.suggestions
 
 
 def test_suggestions():
-    spans = r_matcher("They read us the stories they themselves had written.")
-    suggestions = spans[0]._.suggestions
-    assert all([a == b for a, b in zip(suggestions, output)])
+    assert set(suggestions) <= set(outputs)


### PR DESCRIPTION
Part of #80 is making replaCy support extensions, so this does that. 

Involves:
* Some code reorg - mainly just trying to move stuff out of `__init__.py` and into other files
* more tests
* cleaned up the basic tests, using the testing code we have been using lately, that makes sure matches are for the rule being tested
* add a default Scorer class that KenLMScorer extends
* I think I fixed a (previously unknown) bug on line 186 of suggestion.py

Here is the thing I might hate about this:

* a pipeline component signature is `List[Span] -> None`, that is, it takes a list of spans, and doesn't return... because it modifies that list
* that's not very clean of us, should they return a `List[Span]`?
* see, for example, adding `spacy.util.filter_spans` as a pipeline component, and the weird things I needed to do
