### PR TITLE
disable ALL pipeline components for tokenizing, even unknown ones

### DIFF
--- a/replacy/scorer.py
+++ b/replacy/scorer.py
@@ -50,7 +50,7 @@ class KenLMScorer(Scorer):
                 tok = [token.lower() for token in tok]
 
         elif isinstance(segment, str):
-            doc = self.nlp(segment, disable=["parser", "tagger", "ner"])
+            doc = self.nlp(segment, disable=self.nlp.pipe_names)
             return self.preprocess(doc)
 
         return " ".join(tok)


### PR DESCRIPTION
Without pulling out scorer, this is the only way I can make a neuralcoref replaCy extension play nice with kenLM scoring

because neuralcoref is a pipeline component, and it freaks out if parser is disabled.